### PR TITLE
fix: PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: James Sully <sullyj3@gmail.com>
 _pkgname=sand-timer
 pkgname=${_pkgname}-git
-pkgver=v0.6.0
+pkgver=v0.6.0.r4.c4c5052
 pkgrel=1
 pkgdesc="Command line countdown timers that don't take up a terminal."
 arch=('x86_64')
@@ -10,7 +10,7 @@ url="https://github.com/sullyj3/sand"
 license=('MIT')
 groups=()
 depends=('systemd' 'libnotify')
-makedepends=('git' 'rust' 'cargo')
+makedepends=('git' 'cargo-nightly' 'alsa-lib')
 provides=("${_pkgname}")
 conflicts=("${_pkgname}")
 source=("${_pkgname}::git+https://github.com/sullyj3/sand.git")


### PR DESCRIPTION
Closes #84

Now builds and installs with `extra-x86_64-build`

There are still several E and W messages in the output, but at least it works. We'll deal with those.

There are also various other improvements to be made, c.f. https://wiki.archlinux.org/title/Rust_package_guidelines

@kseistrup I believe this should work, since it works in a clean chroot. I'm going to merge immediately, but give me a shout if it doesn't work for you and I'll reopen #84