### PR TITLE
feat: Timer messages

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -97,8 +97,8 @@ pub fn main(cli_cmd: cli::ClientCommand) -> io::Result<()> {
 
     // TODO: support passing multiple IDs in protocol
     let result: ClientResult<()> = match cli_cmd {
-        cli::ClientCommand::Start(StartArgs { durations }) => {
-            start(&mut conn, durations).inspect_err(|err| eprintln!("{err}"))
+        cli::ClientCommand::Start(StartArgs { durations, message }) => {
+            start(&mut conn, durations, message).inspect_err(|err| eprintln!("{err}"))
         }
         cli::ClientCommand::NextDue => next_due(&mut conn).inspect_err(|err| eprintln!("{err}")),
         cli::ClientCommand::Ls => ls(&mut conn),
@@ -119,9 +119,13 @@ pub fn main(cli_cmd: cli::ClientCommand) -> io::Result<()> {
 // Command handler functions
 /////////////////////////////////////////////////////////////////////////////////////////
 
-fn start(conn: &mut DaemonConnection, durations: Vec<Duration>) -> ClientResult<()> {
+fn start(
+    conn: &mut DaemonConnection,
+    durations: Vec<Duration>,
+    message: Option<String>,
+) -> ClientResult<()> {
     let dur: Duration = durations.iter().sum();
-    let StartTimerResponse::Ok { id } = conn.add_timer(dur)?;
+    let StartTimerResponse::Ok { id } = conn.add_timer(dur, message)?;
 
     let dur_string = dur.format_colon_separated();
     println!("Timer {id} created for {dur_string}.");

--- a/src/client/daemon_connection.rs
+++ b/src/client/daemon_connection.rs
@@ -21,8 +21,12 @@ impl DaemonConnection {
         Ok(Self { read, write })
     }
 
-    pub fn add_timer(&mut self, duration: Duration) -> io::Result<StartTimerResponse> {
-        self.send(Command::StartTimer { duration })?;
+    pub fn add_timer(
+        &mut self,
+        duration: Duration,
+        message: Option<String>,
+    ) -> io::Result<StartTimerResponse> {
+        self.send(Command::StartTimer { duration, message })?;
         self.recv::<StartTimerResponse>()
     }
 

--- a/src/daemon/handle_client.rs
+++ b/src/daemon/handle_client.rs
@@ -18,8 +18,8 @@ async fn handle_command(cmd: Command, ctx: &DaemonCtx) -> Response {
     let now = Instant::now();
     match cmd {
         Command::List => ListResponse::ok(ctx.get_timerinfo_for_client(now)).into(),
-        Command::StartTimer { duration } => {
-            StartTimerResponse::ok(ctx.start_timer(now, duration).await).into()
+        Command::StartTimer { duration, message } => {
+            StartTimerResponse::ok(ctx.start_timer(now, duration, message).await).into()
         }
         Command::PauseTimer(id) => ctx.pause_timer(id, now).into(),
         Command::ResumeTimer(id) => ctx.resume_timer(id, now).into(),

--- a/src/sand/cli.rs
+++ b/src/sand/cli.rs
@@ -46,6 +46,10 @@ impl Cli {
 
 #[derive(Args, Clone)]
 pub struct StartArgs {
+    /// Message to display when the timer is done
+    #[arg(short, long)]
+    pub message: Option<String>,
+
     #[clap(name = "DURATION", value_parser = sand::duration::parse_duration_component, num_args = 1..)]
     pub durations: Vec<Duration>,
 }

--- a/src/sand/message.rs
+++ b/src/sand/message.rs
@@ -16,7 +16,10 @@ use crate::sand::timer::{self, PausedTimer, RunningTimer, Timer, TimerId};
 #[serde(rename_all = "lowercase")]
 pub enum Command {
     List,
-    StartTimer { duration: Duration },
+    StartTimer {
+        duration: Duration,
+        message: Option<String>,
+    },
     PauseTimer(TimerId),
     ResumeTimer(TimerId),
     CancelTimer(TimerId),
@@ -112,6 +115,7 @@ pub struct TimerInfo {
     pub id: TimerId,
     pub state: TimerState,
     pub remaining: Duration,
+    pub message: Option<String>,
 }
 
 impl TimerInfo {
@@ -128,6 +132,7 @@ impl TimerInfo {
             id,
             state,
             remaining,
+            message: timer.message.clone(),
         }
     }
 

--- a/src/sand/timer.rs
+++ b/src/sand/timer.rs
@@ -39,13 +39,15 @@ pub struct RunningTimer {
 pub struct Timer {
     /// The initial duration of the timer. Should not be modified after creation.
     pub initial_duration: Duration,
+    pub message: Option<String>,
     pub state: TimerState,
 }
 
 impl Timer {
-    pub fn new_running(now: Instant, initial_duration: Duration) -> Self {
+    pub fn new_running(now: Instant, initial_duration: Duration, message: Option<String>) -> Self {
         Timer {
             initial_duration,
+            message,
             state: TimerState::Running(RunningTimer {
                 due: now + initial_duration,
             }),

--- a/test.py
+++ b/test.py
@@ -155,6 +155,36 @@ class TestDaemon:
         diff = DeepDiff(expected, response, ignore_order=True)
         assert not diff, f"Response shape mismatch:\n{pformat(diff)}"
 
+    def test_add_with_message(self, daemon):
+        msg_and_response(
+            {
+                "starttimer": {
+                    "duration": {"secs": 10 * 60, "nanos": 0},
+                    "message": "Hello, world!",
+                }
+            }
+        )
+        response = msg_and_response("list")
+        expected_shape = {
+            "ok": {
+                "timers": [
+                    {
+                        "id": 1,
+                        "message": "Hello, world!",
+                        "state": "Running",
+                        "remaining": None,
+                    },
+                ]
+            }
+        }
+        diff = DeepDiff(
+            expected_shape,
+            response,
+            exclude_regex_paths=IGNORE_REMAINING,
+            ignore_order=True,
+        )
+        assert not diff, f"Response shape mismatch:\n{pformat(diff)}"
+
     def test_list(self, daemon):
         msg_and_response({"starttimer": {"duration": {"secs": 10 * 60, "nanos": 0}}})
         msg_and_response({"starttimer": {"duration": {"secs": 20 * 60, "nanos": 0}}})
@@ -164,8 +194,8 @@ class TestDaemon:
         expected_shape = {
             "ok": {
                 "timers": [
-                    {"id": 2, "state": "Running", "remaining": None},
-                    {"id": 1, "state": "Running", "remaining": None},
+                    {"id": 2, "message": None, "state": "Running", "remaining": None},
+                    {"id": 1, "message": None, "state": "Running", "remaining": None},
                 ]
             }
         }
@@ -184,7 +214,11 @@ class TestDaemon:
 
         response = msg_and_response("list")
         expected_shape = {
-            "ok": {"timers": [{"id": 1, "state": "Paused", "remaining": None}]}
+            "ok": {
+                "timers": [
+                    {"id": 1, "message": None, "state": "Paused", "remaining": None}
+                ]
+            }
         }
         diff = DeepDiff(
             expected_shape,
@@ -198,7 +232,11 @@ class TestDaemon:
 
         response = msg_and_response("list")
         expected_shape = {
-            "ok": {"timers": [{"id": 1, "state": "Running", "remaining": None}]}
+            "ok": {
+                "timers": [
+                    {"id": 1, "message": None, "state": "Running", "remaining": None}
+                ]
+            }
         }
         diff = DeepDiff(
             expected_shape,
@@ -223,7 +261,11 @@ class TestDaemon:
 
         response = msg_and_response("list")
         expected_shape = {
-            "ok": {"timers": [{"id": 1, "state": "Paused", "remaining": None}]}
+            "ok": {
+                "timers": [
+                    {"id": 1, "message": None, "state": "Paused", "remaining": None}
+                ]
+            }
         }
         diff = DeepDiff(
             expected_shape,


### PR DESCRIPTION
Closes #53

Todo:
- [x] --message/-m cli flag to add message
- [x] shown in notification
- [x] shown in `sand ls`
- [ ] <strike>shown in `sand next-due`</strike> Might punt on this for now. It needs some design work, it's not clear if it's wanted, and `next-due` might be obsoleted by `--json` stuff anyway
- [x] test
- [x] docs
  - [x] help text
  - [ ] <strike>add to readme example</strike> punting to #105

not implemented:
- `sand again` reusing same message (#115)
